### PR TITLE
Update runtime to 49, update libpanel

### DIFF
--- a/app.drey.Typewriter.json
+++ b/app.drey.Typewriter.json
@@ -35,18 +35,6 @@
     ],
     "modules" : [
         {
-            "name" : "blueprint-compiler",
-            "buildsystem" : "meson",
-            "cleanup": ["*"],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag" : "v0.16.0"
-                }
-            ]
-        },
-        {
             "name" : "libpanel",
             "buildsystem" : "meson",
             "sources" : [

--- a/app.drey.Typewriter.json
+++ b/app.drey.Typewriter.json
@@ -1,7 +1,7 @@
 {
     "id" : "app.drey.Typewriter",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/app.drey.Typewriter.json
+++ b/app.drey.Typewriter.json
@@ -41,7 +41,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/libpanel.git",
-                    "tag" : "1.8.0"
+                    "tag" : "1.10.3",
+                    "commit" : "6620f306917016ef4a534a126bfcdf97ef324e79"
                 }
             ]
         },


### PR DESCRIPTION
`blueprint-compiler` is in the runtime now and can be removed